### PR TITLE
Fixed minor typo in spfs.MarxanData

### DIFF
--- a/R/MarxanData.R
+++ b/R/MarxanData.R
@@ -712,7 +712,7 @@ names.MarxanData<-function(x) {
 #' @rdname spfs
 #' @inheritParams spfs
 spfs.MarxanData<-function(x) {
-	return(x@species$spfs)
+	return(x@species$spf)
 }
 
 #' @export


### PR DESCRIPTION
spfs.MarxanData currently has a bug caused by a minor typo, for example:
data(taspu, tasinvis)
md <- format.MarxanData(taspu, tasinvis, targets=100, spf=1)
spfs(md)